### PR TITLE
Simplify code example

### DIFF
--- a/notebooks/StatisticalDebugger.ipynb
+++ b/notebooks/StatisticalDebugger.ipynb
@@ -1767,8 +1767,7 @@
     "    def rank_by_suspiciousness(self):\n",
     "        \"\"\"Return a list of events, sorted by suspiciousness, highest first.\"\"\"\n",
     "        events = list(self.all_events())\n",
-    "        events.sort(key=lambda event: self.suspiciousness(event),\n",
-    "                   reverse=True)\n",
+    "        events.sort(key=self.suspiciousness, reverse=True)\n",
     "        return events"
    ]
   },


### PR DESCRIPTION
The `key` parameter of the `sort` function takes a function, so there is no need to use a lambda.