### PR TITLE
Fixes and Recommendations in the Textual Parts of the First Three Chapters

### DIFF
--- a/notebooks/Debugger.ipynb
+++ b/notebooks/Debugger.ipynb
@@ -190,6 +190,7 @@
     "* Define _conditions_ under which the execution should _stop_ and hand over control to the debugger. Conditions include\n",
     "    * a particular location is reached\n",
     "    * a particular variable takes a particular value\n",
+    "    * a particular variables is accessed\n",
     "    * or some other condition of choice.\n",
     "* When the program stops, you can _observe_ the current state, including\n",
     "    * the current location\n",
@@ -222,7 +223,7 @@
     }
    },
    "source": [
-    "Debugger interaction typically follows a _loop_ pattern._ First, you identify the location(s) you want to inspect, and tell the debugger to stop execution once one of these _breakpoints_ is reached. Here's a command that could instruct a command-line debugger to stop at Line 239:\n",
+    "Debugger interaction typically follows a _loop_ pattern. First, you identify the location(s) you want to inspect, and tell the debugger to stop execution once one of these _breakpoints_ is reached. Here's a command that could instruct a command-line debugger to stop at Line 239:\n",
     "\n",
     "```\n",
     "(debugger) break 239\n",

--- a/notebooks/Intro_Debugging.ipynb
+++ b/notebooks/Intro_Debugging.ipynb
@@ -210,7 +210,7 @@
     "\n",
     "If you're new to Python, you might first have to understand what the above code does.  We very much recommend the [Python tutorial](https://docs.python.org/3/tutorial/) to get an idea on how Python works.  The most important things for you to understand the above code are these three:\n",
     "\n",
-    "1. Python structures programs through _indentation_, so the function and `for` bodies are defined by being indented;\n",
+    "1. Python structures programs through _indentation_, so the function and `for` bodies are defined by being indented.\n",
     "2. Python is _dynamically typed_, meaning that the type of variables like `c`, `tag`, or `out` is determined at run-time.\n",
     "3. Most of Python's syntactic features are inspired by other common languages, such as control structures (`while`, `if`, `for`), assignments (`=`), or comparisons (`==`, `!=`, `<`).\n",
     "\n",
@@ -313,6 +313,9 @@
     "```html\n",
     "<input type=\"text\" value=\"<your name>\">\n",
     "```\n",
+    "\\todo{One could also show as before the resulting HTML here. -- Björn}\n",
+    "> <input type=\"text\" value=\"<your name>\">\n",
+    "\n",
     "If we feed this string into `remove_html_markup()`, we would expect an empty string as the result. Instead, this is what we get:"
    ]
   },
@@ -483,6 +486,9 @@
    "source": [
     "## A First Fix\n",
     "\n",
+    "\\todo{Maybe make clear, that the proposed solutions are often not final or completely correct but exist to make the process clear. -- Björn}\n",
+    "We will now iteratively try to find a correct solution to our bug. On the way we will come up with different solutions\n",
+    "that bring us closer and closer to the perfect code.\n",
     "Let us now look at the above state machine, and process through our input:\n",
     "\n",
     "```html\n",
@@ -703,7 +709,7 @@
    "source": [
     "### Printf Debugging\n",
     "\n",
-    "When I was a student,  never got any formal training in debugging, so I had to figure this out for myself. What I learned was how to use _debugging output_; in Python, this would be the `print()` function. For instance, I would go and scatter `print()` calls everywhere:"
+    "When I was a student, I never got any formal training in debugging, so I had to figure this out for myself. What I learned was how to use _debugging output_; in Python, this would be the `print()` function. For instance, I would go and scatter `print()` calls everywhere:"
    ]
   },
   {
@@ -752,7 +758,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Yes, one sees what is going on – but this is horribly inefficient!  Think of a 1,000-character input – you'd have to go through 2,000 lines of logs.  It may help you, but it's a total time waster.  Plus, you have to enter these statements, remove them again... it's a maintenance nightmare."
+    "Yes, one sees what is going on – but this is horribly inefficient!  Think of a 1,000-character input – you'd have to go through 1,000 lines of logs.  It may help you, but it's a total time waster.  Plus, you have to enter these statements, remove them again... it's a maintenance nightmare."
    ]
   },
   {
@@ -837,7 +843,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Oh, and of course, I would never back up earlier versions such that I would be able to keep track of what has changed and when."
+    "Oh, and of course, I would never back up earlier versions such that I would be able to keep track of what has changed and when.\n",
+    "Especially keep in mind that our tests will never cover all corner cases. Randomly patching code will just lead to harder to find bugs."
    ]
   },
   {
@@ -896,7 +903,9 @@
     "## From Defect to Failure\n",
     "\n",
     "To understand how to systematically debug a program, we first have to understand how failures come to be. The typical debugging situation looks like this. We have a program (execution), taking some input and producing some output. The output is in *error* (✘), meaning an unwanted and unintended deviation from what is correct, right, or true.\n",
-    "The input, in contrast, is assumed to be correct (✔). (Otherwise, we wouldn't search for the bug in our program, but in whatever produced its input.)"
+    "The input, in contrast, is assumed to be correct (✔). (Otherwise, we wouldn't search for the bug in our program, but in whatever produced its input.)\n",
+    "\\todo{Maybe clarify what a  correct input means here -- one could also pass an incorrect (e.g. malicious) input to the program.\n",
+    "The software should handle such inputs by correctly terminating.}"
    ]
   },
   {
@@ -1104,7 +1113,10 @@
     "\n",
     "* The _defect_ in the code _causes_ a fault in the state when executed.\n",
     "* This _fault_ in the state then _propagates_ through further execution steps...\n",
-    "* ... until it becomes visible as a _failure_."
+    "* ... until it becomes visible as a _failure_.\n",
+    "\n",
+    "Even worse: in most cases the fault often expresses itself first in the control flow rather than the variable contents.\n",
+    "Such a deviation from a normal execution is in general even harder to find."
    ]
   },
   {
@@ -1147,7 +1159,7 @@
     "\n",
     "* Third, executions typically do not come in a handful of steps, as in the diagrams above; instead, they can easily encompass _thousands to millions of steps._ This means that you will have to examine not just one state, but several, making the problem much worse.\n",
     "\n",
-    "To make your search efficient, you thus have to _focus_ your search – starting with most likely causes and gradually progressing to the less probable causes. This is what we call a _debugging strategy_."
+    "To make your search efficient, you thus have to _focus_ your search – starting with most likely causes and gradually progressing to the less probable causes. This is what we call a _debugging strategy_. Intermediate assertions of the program state also come in handy, as they make the cause-effect chain smaller."
    ]
   },
   {
@@ -1423,7 +1435,9 @@
     "* if it holds: proceed as usual\n",
     "* if `cond` does not hold: throw an exception\n",
     "\n",
-    "An `assert` statement _encodes our assumptions_ and as such, should never fail. If it does, well, then something is wrong."
+    "An `assert` statement _encodes our assumptions_ and as such, should never fail. If it does, well, then something is wrong.\n",
+    "Furthermore, `assert` statements break the cause-effect chain into smaller pieces. The observable failure occurs earlier in\n",
+    "the program execution and thus closer to the initial fault."
    ]
   },
   {
@@ -1909,7 +1923,9 @@
    "source": [
     "First, we may want to check that the underlying mistake was not made elsewhere, too.\n",
     "\n",
-    "For an error as with `remove_html_markup()`, it may be wise to check other parts of the code (possibly written by the same programmer) whether Boolean formulas show proper precendence. Consider setting up a static program checker or style checker to catch similar mistakes."
+    "For an error as with `remove_html_markup()`, it may be wise to check other parts of the code (possibly written by the same programmer) whether Boolean formulas show proper precendence. Consider setting up a static program checker or style checker to catch similar mistakes.\n",
+    "Usually if you code in an IDE specifically designed for language you are coding in, you will get hints on so called _code smells_,\n",
+    "parts of your code that are typically erroneous because of bad style or other typical mistakes."
    ]
   },
   {
@@ -1984,7 +2000,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2126,6 +2142,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Debugging Aftermath\n",
+    "\n",
+    "The fix of a bug may lead to a code construct, a more complex condition or another solution which may look strange on first sight.\n",
+    "Often the initial code was easier to understand but did not catch all cases. After fixing a bug it may be beneficial to\n",
+    "write down why the code now looks like this and what caused the more complex construct. A comment right at the fixed location\n",
+    "will help future programmers to not be confused or even re-introduce the bug while refactoring for better readability.\n",
+    "And of course, helpful comments at complex code locations should even exist before something went wrong with the code -- but\n",
+    "thats a chapter in another book.\n",
+    "\n",
     "## History of Debugging\n",
     "\n",
     "Engineers and programmers have long used the term \"bug\" for faults in their systems – as if it were something that crept into an otherwise flawless program to cause the effects that none could explain. And from a psychological standpoint, it is far easier to blame some \"bug\" rather than taking responsibility ourselves. In the end, though, we have to face the fact: We made the bugs, and they are ours to fix.\n",
@@ -2149,7 +2174,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {
     "ipub": {
      "ignore": true
@@ -2163,7 +2188,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {
     "ipub": {
      "ignore": true
@@ -2177,9 +2202,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'quiz' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001B[0;31m---------------------------------------------------------------------------\u001B[0m",
+      "\u001B[0;31mNameError\u001B[0m                                 Traceback (most recent call last)",
+      "\u001B[0;32m<ipython-input-6-5021e804cbe7>\u001B[0m in \u001B[0;36m<module>\u001B[0;34m\u001B[0m\n\u001B[0;32m----> 1\u001B[0;31m quiz('Where has the name \"bug\" been used to denote disruptive events?',\n\u001B[0m\u001B[1;32m      2\u001B[0m      [\n\u001B[1;32m      3\u001B[0m         \u001B[0;34m'In the early days of Morse telegraphy, referring to a special key '\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[1;32m      4\u001B[0m           \u001B[0;34m'that would send a string of dots'\u001B[0m\u001B[0;34m,\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[1;32m      5\u001B[0m         \u001B[0;34m'Among radio technicians to describe a device that '\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n",
+      "\u001B[0;31mNameError\u001B[0m: name 'quiz' is not defined"
+     ]
+    }
+   ],
    "source": [
     "quiz('Where has the name \"bug\" been used to denote disruptive events?',\n",
     "     [\n",
@@ -2197,7 +2234,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "(Source: \\cite{jargon}, \\cite{wikipedia:debugging})"
+    "(Source: \\cite{jargon}, \\cite{wikipedia:debugging}) \\todo{Seems to be still unresolved. -- Björn}"
    ]
   },
   {

--- a/notebooks/Tracer.ipynb
+++ b/notebooks/Tracer.ipynb
@@ -880,7 +880,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Its `traceit()` function _evaluates_ `condition` and reports the current line only if it holds. To this end, it uses the Python `eval()` function which evaluates the condition in the context of the local variables of the program under test. If the condition gets set, we print out three dots to indicate the elapsed time."
+    "Its `traceit()` function _evaluates_ `condition` and reports the current line only if it holds. To this end, it uses the Python `eval()` function which evaluates the condition in the context of the local variables of the program under test. If the condition gets set, we print out three dots to indicate the elapsed time.\n",
+    "\\todo{Couldn't one use lambda expressions or even full fledged functions here, might be more clean than eval, though possibly harder to understand for beginners? -- Björn}"
    ]
   },
   {


### PR DESCRIPTION
I added some fixes and recommendations to the textual part of the Debugging Book in the chapters:

1. Introduction to Debugging ([notebooks/Intro_Debugging.ipynb](https://github.com/uds-se/debuggingbook/compare/master...bjrnmath:master#diff-b3ead8c83d2f4a4da5769343cbef0ff260754608cc4873895ebf3671af0a298a))
2. Tracing Executions ([notebooks/Tracer.ipynb](https://github.com/uds-se/debuggingbook/compare/master...bjrnmath:master#diff-4964836d51c94a6f689213f4029ff6f47bc97945ca82e0dddda52beed829c40f))
3. How Debuggers Work ([notebooks/Debugger.ipynb](https://github.com/uds-se/debuggingbook/compare/master...bjrnmath:master#diff-0d927bed65f0c70efb465bd97fa2fb9839edcb51976e1746ed2cc299b4376798))

The respective changes are very local, diverse, and only in the textual part (no code changes) -- hence it might be the easiest to review them by checking the change history attached to this pull request.

Things that I could not directly resolve are marked with a \todo{}.