### PR TITLE
Bug fix for "Where the Bugs are" chapter

### DIFF
--- a/notebooks/ChangeCounter.ipynb
+++ b/notebooks/ChangeCounter.ipynb
@@ -625,9 +625,6 @@
     "        # Mapping node -> last size seen\n",
     "        self.sizes: Dict[Node, int] = {}\n",
     "\n",
-    "        # All hashes already considered\n",
-    "        self.hashes: Set[str] = set()\n",
-    "\n",
     "        self.mine(**kwargs)"
    ]
   },
@@ -651,7 +648,6 @@
     "\n",
     "        for commit in miner.traverse_commits():\n",
     "            for m in commit.modifications:\n",
-    "                m.hash = commit.hash\n",
     "                m.committer = commit.committer\n",
     "                m.committer_date = commit.committer_date\n",
     "                m.msg = commit.msg\n",
@@ -704,10 +700,8 @@
     "\n",
     "        node = tuple(m.new_path.split('/'))\n",
     "\n",
-    "        if m.hash not in self.hashes:\n",
-    "            self.hashes.add(m.hash)\n",
-    "            self.update_size(node, len(m.source_code) if m.source_code else 0)\n",
-    "            self.update_changes(node, m.msg)\n",
+    "        self.update_size(node, len(m.source_code) if m.source_code else 0)\n",
+    "        self.update_changes(node, m.msg)\n",
     "\n",
     "        self.update_elems(node, m)"
    ]

--- a/notebooks/ChangeCounter.ipynb
+++ b/notebooks/ChangeCounter.ipynb
@@ -180,7 +180,8 @@
    "outputs": [],
    "source": [
     "from pydriller import RepositoryMining  # https://pydriller.readthedocs.io/\n",
-    "from pydriller.domain.commit import Commit"
+    "from pydriller.domain.commit import Commit\n",
+    "from pydriller.domain.commit import Modification"
    ]
   },
   {
@@ -606,7 +607,7 @@
     "        self.log = log\n",
     "\n",
     "        if filter is None:\n",
-    "            def filter(m: Commit) -> bool:\n",
+    "            def filter(m: Modification) -> bool:\n",
     "                return True\n",
     "        assert filter is not None\n",
     "\n",
@@ -673,7 +674,7 @@
    "outputs": [],
    "source": [
     "class ChangeCounter(ChangeCounter):\n",
-    "    def include(self, m: Commit) -> bool:\n",
+    "    def include(self, m: Modification) -> bool:\n",
     "        \"\"\"\n",
     "        Return True if the modification `m` should be included\n",
     "        (default: the `filter` predicate given to the constructor).\n",
@@ -696,7 +697,7 @@
    "outputs": [],
    "source": [
     "class ChangeCounter(ChangeCounter):\n",
-    "    def update_stats(self, m: Commit) -> None:\n",
+    "    def update_stats(self, m: Modification) -> None:\n",
     "        \"\"\"Update counters with modification `m`. Can be extended in subclasses.\"\"\"\n",
     "        if not m.new_path:\n",
     "            return\n",
@@ -774,7 +775,7 @@
    "outputs": [],
    "source": [
     "class ChangeCounter(ChangeCounter):\n",
-    "    def update_elems(self, node: Tuple, m: Commit) -> None:\n",
+    "    def update_elems(self, node: Tuple, m: Modification) -> None:\n",
     "        \"\"\"\n",
     "        Update counters for subelements of `node` with modification `m`.\n",
     "        To be defined in subclasses.\n",
@@ -839,7 +840,7 @@
     "def debuggingbook_change_counter(cls: Type) -> Any:\n",
     "    \"\"\"Instantiate a ChangeCounter (sub)class `cls` with the debuggingbook repo\"\"\"\n",
     "\n",
-    "    def filter(m: Commit) -> bool:\n",
+    "    def filter(m: Modification) -> bool:\n",
     "        \"\"\"Do not include the `docs/` directory; it only holds Web pages\"\"\"\n",
     "        return m.new_path and not m.new_path.startswith('docs/')\n",
     "\n",
@@ -1283,7 +1284,7 @@
     "    Fixes are all commits whose message starts with the word 'Fix: '\n",
     "    \"\"\"\n",
     "\n",
-    "    def include(self, m: Commit) -> bool:\n",
+    "    def include(self, m: Modification) -> bool:\n",
     "        \"\"\"Include all modifications whose commit messages start with 'Fix:'\"\"\"\n",
     "        return super().include(m) and m and m.msg.startswith(\"Fix:\")"
    ]
@@ -1863,7 +1864,7 @@
     "class FineChangeCounter(ChangeCounter):\n",
     "    \"\"\"Count the changes for files in the repository and their elements\"\"\"\n",
     "\n",
-    "    def update_elems(self, node: Node, m: Commit) -> None:\n",
+    "    def update_elems(self, node: Node, m: Modification) -> None:\n",
     "        old_source = m.source_code_before if m.source_code_before else \"\"\n",
     "        new_source = m.source_code if m.source_code else \"\"\n",
     "\n",


### PR DESCRIPTION
Only the first modification (file change) of a commit was considered in update_stats() method, because all modifications borrowed the same hash from the commit. Since the use of ChangeCounter.hashes field is unclear, it was removed.
