### PR TITLE
IntroDebugging: example update

### DIFF
--- a/notebooks/Intro_Debugging.ipynb
+++ b/notebooks/Intro_Debugging.ipynb
@@ -818,7 +818,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "assert remove_html_markup_without_quotes('<\"b\">foo</\"b\">') == 'foo'"
+    "assert remove_html_markup_without_quotes('<b id=\"bar\">foo</b>') == 'foo'"
    ]
   },
   {
@@ -1288,7 +1288,7 @@
     "for i, html in enumerate(['<b>foo</b>',\n",
     "                          '<b>\"foo\"</b>',\n",
     "                          '\"<b>foo</b>\"',\n",
-    "                          '<\"b\">foo</\"b\">']):\n",
+    "                          '<b id=\"bar\">foo</b>']):\n",
     "    result = remove_html_markup(html)\n",
     "    print(\"%-2d %-15s %s\" % (i + 1, html, result))"
    ]
@@ -1304,7 +1304,7 @@
     "|`<b>foo</b>`|`foo`|`foo`|✔|\n",
     "|`<b>\"foo\"</b>`|`\"foo\"`|`foo`|✘|\n",
     "|`\"<b>foo</b>\"`|`\"foo\"`|`<b>foo</b>`|✘|\n",
-    "|`<\"b\">foo</\"b\">`|`foo`|`foo`|✔|\n"
+    "|`<b id=\"bar\">foo</b>`|`foo`|`foo`|✔|\n"
    ]
   },
   {
@@ -1397,7 +1397,7 @@
     "|`<b>foo</b>`|`foo`|`foo`|✔|\n",
     "|`<b>\"foo\"</b>`|`\"foo\"`|`foo`|✘|\n",
     "|`\"<b>foo</b>\"`|`\"foo\"`|`<b>foo</b>`|✘|\n",
-    "|`<\"b\">foo</\"b\">`|`foo`|`foo`|✔|\n",
+    "|`<b id=\"bar\">foo</b>`|`foo`|`foo`|✔|\n",
     "|`\"foo\"`|`\"foo\"`|`foo`|✘|\n"
    ]
   },
@@ -1772,7 +1772,7 @@
     "|`<b>foo</b>`|`foo`|`foo`|✔|\n",
     "|`<b>\"foo\"</b>`|`\"foo\"`|`foo`|✘|\n",
     "|`\"<b>foo</b>\"`|`\"foo\"`|`<b>foo</b>`|✘|\n",
-    "|`<\"b\">foo</\"b\">`|`foo`|`foo`|✔|\n",
+    "|`<b id=\"bar\">foo</b>`|`foo`|`foo`|✔|\n",
     "|`\"foo\"`|`'foo'`|`foo`|✘|\n",
     "|`'foo'`|`'foo'`|`'foo'`|✔|\n",
     "\n",
@@ -1878,7 +1878,7 @@
     "assert remove_html_markup('<b>foo</b>') == 'foo'\n",
     "assert remove_html_markup('<b>\"foo\"</b>') == '\"foo\"'\n",
     "assert remove_html_markup('\"<b>foo</b>\"') == '\"foo\"'\n",
-    "assert remove_html_markup('<\"b\">foo</\"b\">') == 'foo'"
+    "assert remove_html_markup('<b id=\"bar\">foo</b>') == 'foo'"
    ]
   },
   {
@@ -2724,7 +2724,7 @@
     "assert remove_html_markup_with_proper_quotes('<b>foo</b>') == 'foo'\n",
     "assert remove_html_markup_with_proper_quotes('<b>\"foo\"</b>') == '\"foo\"'\n",
     "assert remove_html_markup_with_proper_quotes('\"<b>foo</b>\"') == '\"foo\"'\n",
-    "assert remove_html_markup_with_proper_quotes('<\"b\">foo</\"b\">') == 'foo'"
+    "assert remove_html_markup_with_proper_quotes('<b id=\"bar\">foo</b>') == 'foo'"
    ]
   }
  ],


### PR DESCRIPTION
Since <"b">foo</"b"> is not a valid html (among other valid examples), it would make sense to substitute it with a valid form with the similar quotes position: <b id="bar">foo</b>