### PR TITLE
Fix typos in ChangeDebugger.ipnyb

### DIFF
--- a/notebooks/ChangeDebugger.ipynb
+++ b/notebooks/ChangeDebugger.ipynb
@@ -610,7 +610,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "With `git add` and `git commit`, we add the file to our version repository. The `-m` option defines a _message_ for the commit; this is how we (and potential co-workers_ can later retrieve information on what has changed, and why. (The messages we use here are deliberately kept short.)"
+    "With `git add` and `git commit`, we add the file to our version repository. The `-m` option defines a _message_ for the commit; this is how we (and potential co-workers) can later retrieve information on what has changed, and why. (The messages we use here are deliberately kept short.)"
    ]
   },
   {
@@ -1048,7 +1048,7 @@
    "source": [
     "Note that the failure does _not_ occur in the very first version, as introduced above. So the simple question is:\n",
     "\n",
-    "* What is the change that cause the failure?"
+    "* What is the change that caused the failure?"
    ]
   },
   {
@@ -1433,7 +1433,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We mark the version as `bad`. `git bisect` then checks out version 2 as the last version to assess,"
+    "We mark the version as `bad`. `git bisect` then checks out version 2 as the last version to assess."
    ]
   },
   {
@@ -2200,7 +2200,7 @@
    "source": [
     "### A Minimal Difference\n",
     "\n",
-    "Can we narrow this down even further? Yes, we can! The idea is to not only search for the minimal set of patches to be applied on the passing version, but to actually seek a minimal _difference_ betweem two patch sets. That is, we obtain \n",
+    "Can we narrow this down even further? Yes, we can! The idea is to not only search for the minimal set of patches to be applied on the passing version, but to actually seek a minimal _difference_ between two patch sets. That is, we obtain \n",
     "\n",
     "* one set of _passing_ patches that, when applied, still passes;\n",
     "* one set of _failing_ patches that, when applied, fails;\n",


### PR DESCRIPTION
This fixes some minor typos in ChangeDebugger.ipynb.